### PR TITLE
hotfix - header zindex bug

### DIFF
--- a/src/layout/styles.js
+++ b/src/layout/styles.js
@@ -45,6 +45,7 @@ const BodyGeneral = styled.div`
     align-items: center;
     justify-content: flex-start;
     position: fixed;
+    z-index: 25;
     top: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
header was below other page elements on the symptoms page